### PR TITLE
Basic auth and ciient directories

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,10 +1,2 @@
 FLASK_APP=converter_app.app
 FLASK_ENV=development
-
-CORS=True
-
-# LOG_LEVEL=ERROR
-# LOG_LEVEL=DEBUG
-# LOG_LEVEL=INFO
-
-# PROFILES_DIR=profiles

--- a/.env.prod
+++ b/.env.prod
@@ -1,12 +1,6 @@
 FLASK_APP=converter_app.app
 FLASK_ENV=production
 
-LOG_LEVEL=INFO
-LOG_FILE=/var/log/chemotion-converter/application.log
-
-PROFILES_DIR=/srv/chemotion/profiles
-MAX_CONTENT_LENGTH = 10M
-
 GUNICORN_BIN=/srv/chemotion/env/bin/gunicorn
 GUNICORN_WORKER=3
 GUNICORN_PORT=9000

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 /env
 /.env
 
+/config.yml
 /log
 /tmp
 /profiles

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,0 +1,9 @@
+secret_key: not a secret key
+profiles_dir: /srv/chemotion/profiles
+max_content_length: 10G
+cors: false
+log_level: info
+log_file: /var/log/chemotion/converter.log
+clients:
+- client_id:
+  client_secret:

--- a/converter_app/app.py
+++ b/converter_app/app.py
@@ -121,17 +121,19 @@ def create_app(test_config=None):
     @app.route('/profiles', methods=['GET'])
     @auth.login_required
     def list_profiles():
-        profiles = Profile.list()
+        client_id = auth.current_user()
+        profiles = Profile.list(client_id)
         return jsonify([profile.as_dict for profile in profiles]), 200
 
     @app.route('/profiles', methods=['POST'])
     @auth.login_required
     def create_profile():
+        client_id = auth.current_user()
         profile_data = json.loads(request.data)
         profile = Profile(profile_data)
 
         if profile.clean():
-            profile.save()
+            profile.save(client_id)
             return jsonify(profile.as_dict), 201
         else:
             return jsonify(profile.errors), 400
@@ -139,7 +141,8 @@ def create_app(test_config=None):
     @app.route('/profiles/<profile_id>', methods=['GET'])
     @auth.login_required
     def retrieve_profile(profile_id):
-        profile = Profile.retrieve(profile_id)
+        client_id = auth.current_user()
+        profile = Profile.retrieve(client_id, profile_id)
         if profile:
             return jsonify(profile.as_dict), 200
         else:
@@ -148,7 +151,8 @@ def create_app(test_config=None):
     @app.route('/profiles/<profile_id>', methods=['PUT'])
     @auth.login_required
     def update_profile(profile_id):
-        profile = Profile.retrieve(profile_id)
+        client_id = auth.current_user()
+        profile = Profile.retrieve(client_id, profile_id)
         if profile:
             try:
                 profile.data = json.loads(request.data)
@@ -156,7 +160,7 @@ def create_app(test_config=None):
                 return jsonify({'error': 'Bad request'}), 400
 
             if profile.clean():
-                profile.save()
+                profile.save(client_id)
                 return jsonify(profile.as_dict), 200
             else:
                 return jsonify(profile.errors), 400
@@ -166,7 +170,8 @@ def create_app(test_config=None):
     @app.route('/profiles/<profile_id>', methods=['DELETE'])
     @auth.login_required
     def delete_profile(profile_id):
-        profile = Profile.retrieve(profile_id)
+        client_id = auth.current_user()
+        profile = Profile.retrieve(client_id, profile_id)
         if profile:
             profile.delete()
             return '', 204

--- a/converter_app/converters.py
+++ b/converter_app/converters.py
@@ -46,7 +46,7 @@ class Converter(object):
         if table_index is not None:
             try:
                 if int(table_index) >= len(data):
-                  return False
+                    return False
 
                 table = data[int(table_index)]
             except KeyError:

--- a/converter_app/models.py
+++ b/converter_app/models.py
@@ -44,8 +44,8 @@ class Profile(object):
         if not self.errors:
             return True
 
-    def save(self):
-        profiles_path = Path(current_app.config['PROFILES_DIR'])
+    def save(self, client_id):
+        profiles_path = Path(current_app.config['PROFILES_DIR']).joinpath(client_id)
         profiles_path.mkdir(parents=True, exist_ok=True)
 
         if self.id is None:
@@ -71,8 +71,8 @@ class Profile(object):
         }
 
     @classmethod
-    def list(cls):
-        profiles_path = Path(current_app.config['PROFILES_DIR'])
+    def list(cls, client_id):
+        profiles_path = Path(current_app.config['PROFILES_DIR']).joinpath(client_id)
 
         if profiles_path.exists():
             for file_path in Path.iterdir(profiles_path):
@@ -83,8 +83,8 @@ class Profile(object):
             return []
 
     @classmethod
-    def retrieve(cls, profile_id):
-        profiles_path = Path(current_app.config['PROFILES_DIR'])
+    def retrieve(cls, client_id, profile_id):
+        profiles_path = Path(current_app.config['PROFILES_DIR']).joinpath(client_id)
 
         # make sure that its really a uuid, this should prevent file system traversal
         try:

--- a/converter_app/readers/ascii.py
+++ b/converter_app/readers/ascii.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import string
 
 from .base import Reader
 

--- a/converter_app/readers/csv.py
+++ b/converter_app/readers/csv.py
@@ -2,7 +2,6 @@ import copy
 import csv
 import io
 import logging
-import string
 
 from .base import Reader
 

--- a/converter_app/readers/excel.py
+++ b/converter_app/readers/excel.py
@@ -1,5 +1,4 @@
 import logging
-import string
 import zipfile
 
 import openpyxl

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,4 +3,5 @@ flask-cors
 gunicorn
 python-dotenv
 python-magic
+pyyaml
 openpyxl


### PR DESCRIPTION
This PR changes the following things:

* Use config.yml for app config and .env only for environment vars. This is more the "Chemotion style" and is needed to store client_id/client_secret pairs.
* Add HTTP basic auth to access the API. We could also use a token authentication, but basic auth is also supported by the browser. In a setup where the chemotion-converter-client is located under `/` and the api under `/api/v1` (with the same host) the credentials can be shared.
* Use the client_id (aka. username) from the basic auth to separate client state, i.e. to store profiles in different directories. The profile itself does not carry the client_id so it can be copied from client to client (manually on the server) when needed.