### PR TITLE
Refactor csv

### DIFF
--- a/converter_app/readers/base.py
+++ b/converter_app/readers/base.py
@@ -38,5 +38,6 @@ class Reader(object):
             'file_name': self.file_name,
             'content_type': self.content_type,
             'mime_type': self.mime_type,
-            'extension': self.extension
+            'extension': self.extension,
+            'reader': self.__class__.__name__
         }

--- a/converter_app/readers/csv.py
+++ b/converter_app/readers/csv.py
@@ -43,32 +43,19 @@ class CSVReader(Reader):
         for line, row in zip(self.lines, self.reader):
             shape = self.get_shape(row)
 
-            if 's' in shape:
-                # there is a string in this row, this cant be the table
+            if 'f' in shape and shape == previous_shape:
+                if tables[-1]['rows'] == []:
+                    # move the previous row with the same shape from the header to the table
+                    tables[-1]['header'].pop()
+                    tables[-1]['rows'].append(previous_row)
 
+                tables[-1]['rows'].append(row)
+
+            else:
                 if tables[-1]['rows']:
-                    # if a table is already there, this must be a new header
-                    self.append_table(tables)
-
-                tables[-1]['header'].append(line)
-
-            elif 'f' in shape:
-                if tables[-1]['rows'] and shape != previous_shape:
                     # start a new table if the shape has changed
                     self.append_table(tables)
 
-                elif tables[-1]['rows'] == [] and [bool(s) for s in shape] == [bool(s) for s in previous_shape]:
-                    # move the previous row with a "similar" shape from the header to the table
-                    tables[-1]['header'].pop()
-                    values = [previous_row[i] for i, value in enumerate(previous_shape) if value != '']
-                    tables[-1]['rows'].append(values)
-
-                # this row has floats but no strings, this is the "real" table
-                values = [row[i] for i, value in enumerate(shape) if value == 'f']
-                tables[-1]['rows'].append(values)
-
-            else:
-                # empty lines are preserved for the header
                 tables[-1]['header'].append(line)
 
             # store shape and row for the next iteration


### PR DESCRIPTION
* Add reader class name to metadata (for convenience)
* Refactor CSV reader: Empty columns are not longer skipped, but string columns are possible and "sparse" tables will should work as well. Column names will not apear in the table rows anymore (but in the header.)