### PR TITLE
Refactor readers so that all metadata is str

### DIFF
--- a/converter_app/app.py
+++ b/converter_app/app.py
@@ -146,6 +146,7 @@ def create_app(test_config=None):
 
             if reader:
                 reader.process()
+                reader.validate()
 
                 # only return the first 10 rows of each table
                 for index, table in enumerate(reader.tables):

--- a/converter_app/readers/ascii.py
+++ b/converter_app/readers/ascii.py
@@ -65,7 +65,7 @@ class AsciiReader(Reader):
                     'name': 'Column #{}'.format(idx)
                 } for idx, value in enumerate(table['rows'][0])]
 
-            table['metadata']['rows'] = len(table['rows'])
-            table['metadata']['columns'] = len(table['columns'])
+            table['metadata']['rows'] = str(len(table['rows']))
+            table['metadata']['columns'] = str(len(table['columns']))
 
         return tables

--- a/converter_app/readers/base.py
+++ b/converter_app/readers/base.py
@@ -39,7 +39,7 @@ class Reader(object):
             if not isinstance(value, str):
                 class_name = type(value).__name__
                 logger.warn(f'metadata {key}="{value}" is not of type str, but {class_name} ({self.identifier})')
-                
+
     def get_tables(self):
         raise NotImplementedError
 

--- a/converter_app/readers/base.py
+++ b/converter_app/readers/base.py
@@ -28,13 +28,25 @@ class Reader(object):
         self.tables = self.get_tables()
         self.metadata = self.get_metadata()
 
+    def validate(self):
+        for table_index, table in enumerate(self.tables):
+            for key, value in table['metadata'].items():
+                if not isinstance(value, str):
+                    class_name = type(value).__name__
+                    logger.warn(f'metadata Table #{table_index} {key}="{value}" is not of type str, but {class_name} ({self.identifier})')
+
+        for key, value in self.metadata.items():
+            if not isinstance(value, str):
+                class_name = type(value).__name__
+                logger.warn(f'metadata {key}="{value}" is not of type str, but {class_name} ({self.identifier})')
+                
     def get_tables(self):
         raise NotImplementedError
 
     def get_metadata(self):
         return {
             'file_name': self.file.name,
-            'content_type': self.file.content_type,
+            'content_type': self.file.content_type or '',
             'mime_type': self.file.mime_type,
             'extension': self.file.suffix,
             'reader': self.__class__.__name__,

--- a/converter_app/readers/brml.py
+++ b/converter_app/readers/brml.py
@@ -56,7 +56,7 @@ class BrmlReader(Reader):
 
                                 table['rows'].append(row)
 
-                    table['metadata']['rows'] = len(table['rows'])
-                    table['metadata']['columns'] = len(table['columns'])
+                    table['metadata']['rows'] = str(len(table['rows']))
+                    table['metadata']['columns'] = str(len(table['columns']))
 
         return tables

--- a/converter_app/readers/csv.py
+++ b/converter_app/readers/csv.py
@@ -108,19 +108,19 @@ class CSVReader(Reader):
                         'name': 'Column #{} ({})'.format(idx, name) if name else 'Column #{}'.format(idx)
                     })
 
-            table['metadata']['rows'] = len(table['rows'])
-            table['metadata']['columns'] = len(table['columns'])
+            table['metadata']['rows'] = str(len(table['rows']))
+            table['metadata']['columns'] = str(len(table['columns']))
 
         return tables
 
     def get_metadata(self):
         metadata = super().get_metadata()
         metadata['lineterminator'] = self.lineterminators.get(self.file.csv_dialect.lineterminator, self.file.csv_dialect.lineterminator)
-        metadata['quoting'] = self.file.csv_dialect.quoting
-        metadata['doublequote'] = self.file.csv_dialect.doublequote
+        metadata['quoting'] = str(self.file.csv_dialect.quoting)
+        metadata['doublequote'] = str(self.file.csv_dialect.doublequote)
         metadata['delimiter'] = self.delimiters.get(self.file.csv_dialect.delimiter, self.file.csv_dialect.delimiter)
         metadata['quotechar'] = self.file.csv_dialect.quotechar
-        metadata['skipinitialspace'] = self.file.csv_dialect.skipinitialspace
+        metadata['skipinitialspace'] = str(self.file.csv_dialect.skipinitialspace)
         return metadata
 
     def get_shape(self, row):

--- a/converter_app/readers/dta.py
+++ b/converter_app/readers/dta.py
@@ -75,7 +75,7 @@ class DtaReader(Reader):
             if row.startswith('CURVE'):
                 header = False
 
-            table['metadata']['rows'] = len(table['rows'])
-            table['metadata']['columns'] = len(table['columns'])
+            table['metadata']['rows'] = str(len(table['rows']))
+            table['metadata']['columns'] = str(len(table['columns']))
 
         return tables

--- a/converter_app/readers/excel.py
+++ b/converter_app/readers/excel.py
@@ -70,8 +70,8 @@ class ExcelReader(Reader):
                     'name': 'Column #{}'.format(idx)
                 } for idx, value in enumerate(table['rows'][0])]
 
-            table['metadata']['rows'] = len(table['rows'])
-            table['metadata']['columns'] = len(table['columns'])
+            table['metadata']['rows'] = str(len(table['rows']))
+            table['metadata']['columns'] = str(len(table['columns']))
 
         return tables
 

--- a/converter_app/readers/jasco.py
+++ b/converter_app/readers/jasco.py
@@ -44,7 +44,7 @@ class JascoReader(Reader):
                         'name': 'Column #{}'.format(idx)
                     })
 
-            table['metadata']['rows'] = len(table['rows'])
-            table['metadata']['columns'] = len(table['columns'])
+            table['metadata']['rows'] = str(len(table['rows']))
+            table['metadata']['columns'] = str(len(table['columns']))
 
         return tables

--- a/converter_app/readers/pssession.py
+++ b/converter_app/readers/pssession.py
@@ -68,8 +68,8 @@ class PsSessionReader(Reader):
             table['rows'] = list(map(list, zip(*columns)))
 
             # add number of rows and columns to metadata
-            table['metadata']['rows'] = len(table['rows'])
-            table['metadata']['columns'] = len(table['columns'])
+            table['metadata']['rows'] = str(len(table['rows']))
+            table['metadata']['columns'] = str(len(table['columns']))
 
         return tables
 


### PR DESCRIPTION
This PR refactors the readers so that all (file and table) metadata are `str` and adds warnings if it is not the case.