### PR TITLE
Scalar bug fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__/
 /playground.py
 /run_client.sh
 /.idea/vcs.xml
+.idea/

--- a/converter_app/converters.py
+++ b/converter_app/converters.py
@@ -70,6 +70,11 @@ class Converter(object):
                 # return immediately if one (non optional) identifier does not match
                 return False
 
+            if match and 'value' in match:
+                match_operations = identifier.get('operations', [])
+                for match_operation in match_operations:
+                    match['value'] = self.run_identifier_operation(match['value'], match_operation)
+
             # store match
             self.matches.append({
                 'identifier': identifier,
@@ -205,10 +210,6 @@ class Converter(object):
                         output_table_index == match_output_table_index or
                         match_output_table_index is None
                     ):
-                        match_operations = match.get('identifier', {}).get('operations', [])
-                        for match_operation in match_operations:
-                            match_value = self.run_identifier_operation(match_value, match_operation)
-
                         header[match_output_key] = match_value
 
             x_column = output_table.get('table', {}).get('xColumn')


### PR DESCRIPTION
Bug appears if scalar operators are applied to metadata fields with no related output table.
_Fix:_ moved operator application from the output table section into the identifier match function.