### PR TITLE
Fixed .SEC column separator error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__/
 /playground.py
 /run_client.sh
 /.idea/vcs.xml
+.idea/

--- a/converter_app/readers/sec.py
+++ b/converter_app/readers/sec.py
@@ -53,7 +53,7 @@ class SecReader(Reader):
         return self._is_calibration > 0
 
     def _split_key_val(self, line, table):
-        line_array = re.sub(r'\[%]\t', '[%] ', line).split('\t')
+        line_array = line.split('\t')
         key = None
         line_key = None
         counter = 0


### PR DESCRIPTION
Bug appears during the output-table-column-header separation if the headers contains  a integral column
_Fix:_ removed regex