### PR TITLE
fix(readers): import jcamp read function across jcamp 1.3.1 rename

### DIFF
--- a/converter_app/readers/jcamp_conv_reader.py
+++ b/converter_app/readers/jcamp_conv_reader.py
@@ -1,6 +1,10 @@
 import logging
 
-from jcamp import jcamp_read
+try:
+    # jcamp >= 1.3.1 renamed jcamp_read -> read (and jcamp_readfile -> readfile)
+    from jcamp import read as jcamp_read
+except ImportError:  # jcamp <= 1.3.0
+    from jcamp import jcamp_read
 from numpy import ndarray
 
 from converter_app.readers.helper.base import Reader


### PR DESCRIPTION
## Problem

CI `build (3.13)` fails at **import time**:

```
File ".../converter_app/readers/jcamp_conv_reader.py", line 3, in <module>
    from jcamp import jcamp_read
ImportError: cannot import name 'jcamp_read' from 'jcamp'
```

`jcamp` **1.3.1** (released 2026-07-09) renamed `jcamp_read` → `read` (and
`jcamp_readfile` → `readfile`). The dependency is pinned `jcamp==1.*` (unbounded, see
`pyproject.toml`), so CI resolves jcamp ≥ 1.3.1 (currently 1.3.2, released 2026-07-15) and
the old symbol is gone.

Because `converter_app/readers/__init__.py` imports **every** reader eagerly, a single
unimportable reader aborts the entire `python -m test_manager` run before any test executes
— which is why the whole `build (3.13)` job goes red. This is repo-wide dependency drift, not
tied to any feature branch; it currently surfaces on open PRs (e.g. #242) whose CI happened to
resolve the new jcamp.

> `build (3.12)` still passes only because its Actions dependency cache holds an older jcamp
> (1.3.0) that still has `jcamp_read`; it will break too once that cache is rebuilt.

## Fix

Import the function under a `try/except` that works on both sides of the rename, keeping
compatibility across the whole pinned `1.*` range:

```python
try:
    # jcamp >= 1.3.1 renamed jcamp_read -> read
    from jcamp import read as jcamp_read
except ImportError:  # jcamp <= 1.3.0
    from jcamp import jcamp_read
```

The new `read(filehandle)` has the same signature as the old `jcamp_read(filehandle)`, so the
call site is unchanged. `jcamp_conv_reader.py` is the only file in the repo using the renamed
symbols.

## Verification

Verified the import shim resolves correctly against the version breaking CI:

```
$ pip install jcamp==1.3.2
installed jcamp has read: True | jcamp_read: False
shim resolves to: read
```

and falls back to `jcamp_read` on jcamp ≤ 1.3.0.

## Follow-up (not in this PR)

The unbounded `jcamp==1.*` pin is the underlying hazard; consider tightening pins for deps
that ship breaking minor releases. Also worth considering: making `readers/__init__.py` import
readers lazily so one broken optional reader can't abort the whole app/test import.