### PR TITLE
fix(migration): repair profiles whose last_migration overstates what ran

### DIFF
--- a/converter_app/profile_migration/utils/registration.py
+++ b/converter_app/profile_migration/utils/registration.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import logging
 import traceback
 from pathlib import Path
 from typing import Optional
@@ -8,6 +9,9 @@ import jsonpatch
 
 from converter_app.models import Profile
 from converter_app.utils import get_app_root, cli_home_path
+from converter_app.validation import profile_validation_errors
+
+logger = logging.getLogger(__name__)
 
 
 class Migrations:
@@ -152,7 +156,57 @@ class Migrations:
             last_migration = profile.data.get('last_migration', '')
         is_migration_applied = self.restore_unknown_migrations(profile, add_history)
         is_migration_applied |= self._up_migration(last_migration, profile, add_history)
+        if not force:
+            is_migration_applied |= self._repair_untrusted_checkpoint(profile, add_history)
         return is_migration_applied
+
+    def _repair_untrusted_checkpoint(self, profile: Profile, add_history: bool = True) -> bool:
+        """
+        Heals a profile whose ``last_migration`` overstates what was actually applied.
+
+        The checkpoint is only a claim; the schema is the ground truth. Real profiles
+        exist that are stamped past a field-adding migration yet lack its field (e.g.
+        ``rootOntology``, added by 20250908063445, missing on profiles checkpointed at
+        20260113143334). Resuming from such a checkpoint skips the field-adder forever,
+        so the profile stays structurally invalid no matter how often it is migrated --
+        it only ever looked fixed because the checkpoint kept advancing. Downstream that
+        surfaces as a hard failure far from the cause (the RDF writer reading the absent
+        key), and the only escape used to be an operator running ``migrate --force``.
+
+        So when a profile does not validate after a normal resume, distrust the
+        checkpoint and replay the chain from the root. The replay is adopted when it
+        leaves no violation the profile did not already have -- a subset check rather
+        than a clean bill of health, because a profile can carry an unrelated defect no
+        migration claims to fix (a table header of nulls, say). Insisting on full
+        validity there would throw away a replay that did restore the missing fields.
+        If the replay introduces anything new, the profile is restored untouched, so a
+        repair attempt can never leave it worse than it was found.
+
+        :return: True when the replay repaired the profile and it must be saved
+        """
+        before = profile_validation_errors(profile.data)
+        if not before:
+            return False
+
+        checkpoint = profile.data.get('last_migration')
+        snapshot = copy.deepcopy(profile.data)
+        self._up_migration('', profile, add_history)
+        after = profile_validation_errors(profile.data)
+
+        if after <= before:
+            logger.warning(
+                'Profile %s: checkpoint %s overstated the applied migrations; replayed '
+                'the chain from the root and cleared %d of %d violation(s).%s',
+                profile.data.get('id'), checkpoint, len(before - after), len(before),
+                '' if not after else f' Still unresolved: {sorted(after)}.')
+            return True
+
+        profile.data = snapshot
+        logger.error(
+            'Profile %s: replaying the migration chain from the root (checkpoint %s) '
+            'introduced new violations %s; left unchanged.',
+            profile.data.get('id'), checkpoint, sorted(after - before))
+        return False
 
     def _up_migration(self, last_migration, profile, add_history: bool = True):
         if last_migration not in self._registry_tree:

--- a/converter_app/validation/__init__.py
+++ b/converter_app/validation/__init__.py
@@ -29,6 +29,29 @@ def validate_profile(json_to_test: dict):
     validator.validate(json_to_test)
 
 
+def profile_validation_errors(json_to_test: dict) -> set[str]:
+    """
+    Reports every way ``json_to_test`` violates the profile schema, rather than
+    stopping at the first one like :func:`validate_profile`.
+
+    Callers use this to compare a profile before and after a transformation: an empty
+    set means valid, and a result that is a subset of the original means the
+    transformation fixed some violations without introducing any.
+
+    The message is part of the signature, not decoration: ``required`` reports one
+    error per absent property, all sharing the same path and validator, so without it
+    every missing field would collapse into a single indistinguishable entry and a
+    transformation that dropped one field while adding another would look like a no-op.
+
+    :return: one ``path: validator: message`` signature per violation, stable across runs
+    """
+    validator = SchemaRegistry.instance().validator_for('chemconverter://profile/base/draft-01')
+    return {
+        f"{'->'.join(str(x) for x in e.absolute_path)}: {e.validator}: {e.message}"
+        for e in validator.iter_errors(json_to_test)
+    }
+
+
 def validate_all_profiles(profile_dir: str | Path):
     for client_path in Path(profile_dir).iterdir():
         for profile in client_path.glob("*.json"):

--- a/converter_app/writers/rdf.py
+++ b/converter_app/writers/rdf.py
@@ -8,6 +8,28 @@ from converter_app.writers.base import Writer
 
 logger = logging.getLogger(__name__)
 
+# Fallback for a profile that reached the writer without a rootOntology. Migration
+# 20250908063445 seeds exactly this term, but a profile can still arrive without it
+# (an unmigratable one, or a client POSTing a hand-built profile), and the writer must
+# degrade to the generic assay rather than fail the whole conversion. The migration
+# keeps its own copy on purpose: migrations are historical artefacts and must not shift
+# when this default is retuned.
+DEFAULT_ROOT_ONTOLOGY = {
+    'description': [
+        'A planned process that has the objective to produce information about a '
+        'material entity (the evaluant) by examining it.'
+    ],
+    'id': 'obi:class:http://purl.obolibrary.org/obo/OBI_0000070',
+    'iri': 'http://purl.obolibrary.org/obo/OBI_0000070',
+    'label': 'assay',
+    'namespace': 'http://purl.obolibrary.org/obo/',
+    'obo_id': 'OBI:0000070',
+    'ontology_name': 'obi',
+    'ontology_prefix': 'OBI',
+    'short_form': 'OBI_0000070',
+    'type': 'class'
+}
+
 
 class RDFWriter(Writer):
     suffix = '.ttl'
@@ -162,12 +184,23 @@ class RDFWriter(Writer):
         profile = self._converter.profile.as_dict
         temp_namespaces = defaultdict(set)
         temp_namespaces[Namespace(self._namespace)].add(self._namespace_name)
-        self.root_ontology = profile['rootOntology']
-        self.subjects += profile['subjects']
-        self.predicates += profile['predicates']
-        self.datatypes += profile['datatypes']
-        self.objects += profile['objects']
-        self.instances.update(profile['subjectInstances'])
+        # Read defensively: these are all fields that migrations add, so a profile whose
+        # migration never completed reaches this point without them. Indexing here used
+        # to raise KeyError mid-conversion, which the API surfaced as a bare HTTP 500 and
+        # callers reported as "conversion silently stopped working". An incomplete
+        # profile now yields a thinner graph instead of no graph at all.
+        root_ontology = profile.get('rootOntology')
+        if not isinstance(root_ontology, dict):
+            logger.warning(
+                'Profile %s has no rootOntology; falling back to the generic assay term. '
+                'The profile is likely mid-migration.', profile.get('id'))
+            root_ontology = DEFAULT_ROOT_ONTOLOGY
+        self.root_ontology = root_ontology
+        self.subjects += profile.get('subjects') or []
+        self.predicates += profile.get('predicates') or []
+        self.datatypes += profile.get('datatypes') or []
+        self.objects += profile.get('objects') or []
+        self.instances.update(profile.get('subjectInstances') or {})
         identifiers = [i['identifier'] | i['result'] for i in self._converter.get_matches(rdf=True) if i['result']]
 
         for element in [self.root_ontology] + self.subjects + self.predicates + self.datatypes + self.objects:

--- a/test_static/test_profile_migration_resume.py
+++ b/test_static/test_profile_migration_resume.py
@@ -12,9 +12,16 @@ The second half of the file covers the follow-on bug: once the chain *does* run 
 the tip, migration 20260430125545 seeds ``diff_history`` with an empty list, and
 gating the history append on that list's truthiness froze the profile's version
 forever (refs: #241).
+
+The third part covers what tolerating the missing fields did *not* fix: the profile
+came out the far end of the chain still missing them, stamped at the tip and so
+never revisited, and the conversion blew up later in the RDF writer instead. The
+runner now treats the checkpoint as a claim and the schema as the ground truth,
+replaying the chain from the root when the two disagree.
 """
 import copy
 import tempfile
+from types import SimpleNamespace
 
 import flask
 import pytest
@@ -23,8 +30,17 @@ import pytest
 import converter_app.profile_migration  # noqa: F401
 from converter_app.profile_migration.utils.registration import Migrations
 from converter_app.models import Profile
+from converter_app.validation import profile_validation_errors
+from converter_app.writers.rdf import RDFWriter, DEFAULT_ROOT_ONTOLOGY
 
 CHECKPOINT = '20260113143334'
+
+# Fields that migrations add and that the real legacy profiles lack despite being
+# stamped past the migrations that add them.
+MIGRATION_ADDED_FIELDS = (
+    'subjectInstances', 'rootOntology', 'subjects', 'predicates', 'datatypes',
+    'objects', 'reactionVariations',
+)
 
 
 def _migration(identifier):
@@ -201,3 +217,160 @@ def test_migration_changes_are_recorded_when_history_is_enabled(profiles_app):  
     assert all(t.startswith('migration:') for t in triggers)
     # Version advanced once per recorded migration, from the 1.0 seed.
     assert profile.data['profile_version'] == f'1.{len(triggers)}'
+
+
+# --- self-healing of an untrustworthy checkpoint ------------------------------
+
+
+def _valid_profile(**overrides):
+    """A profile shaped the way the tip of the migration chain leaves one: schema-valid."""
+    profile = {
+        'id': '15400217-b730-47db-9d5c-a300bce7ae95',
+        'last_migration': Migrations().last,
+        'title': 'Tip profile',
+        'description': '',
+        'converter_version': '1.9.2',
+        'profile_version': '1.0',
+        'isDisabled': False,
+        'ontology': '',
+        'devices': [],
+        'software': [],
+        'tables': [],
+        'identifiers': [],
+        'diff_history': [],
+        'subjectInstances': {},
+        'subjects': [],
+        'predicates': [],
+        'datatypes': [],
+        'objects': [],
+        'reactionVariations': {'elements': [], 'identifiers': []},
+        'data': [{'metadata': {'file_name': 'x.txt'}, 'tables': [
+            {'header': ['h'], 'metadata': {}, 'rows': [],
+             'columns': [{'name': 'c0', 'key': '0'}]},
+        ]}],
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _legacy_checkpoint_profile(**overrides):
+    """The real failure shape: stamped past the field-adders, without their fields."""
+    profile = _valid_profile(last_migration=CHECKPOINT, **overrides)
+    for field in MIGRATION_ADDED_FIELDS:
+        profile.pop(field, None)
+    return profile
+
+
+def test_fixture_matches_the_real_failure_shape():
+    # Guards the tests below: the fixture is only meaningful while it reproduces the
+    # bug, i.e. is invalid *and* checkpointed past the migrations that would fix it.
+    assert profile_validation_errors(_valid_profile()) == set()
+    assert profile_validation_errors(_legacy_checkpoint_profile()) != set()
+
+
+def test_legacy_checkpoint_profile_is_repaired_to_validity():
+    # The point of the fix: a plain resume (no force) must not just avoid crashing,
+    # it must leave a valid profile behind.
+    profile = Profile(_legacy_checkpoint_profile(), client_id='chemotion')
+
+    applied = Migrations().migrate_profile(profile, force=False, add_history=False)
+
+    assert applied, 'the repair must report back so the caller persists it'
+    assert profile_validation_errors(profile.data) == set()
+    assert isinstance(profile.data['rootOntology'], dict)
+    assert profile.data['last_migration'] == Migrations().last
+
+
+def test_repaired_profile_is_stable_on_a_second_pass():
+    # Every boot runs the migration, so the repair has to be idempotent: the second
+    # pass must find nothing to do rather than replaying the chain forever.
+    profile = Profile(_legacy_checkpoint_profile(), client_id='chemotion')
+    Migrations().migrate_profile(profile, force=False, add_history=False)
+    repaired = copy.deepcopy(profile.data)
+
+    assert Migrations().migrate_profile(profile, force=False, add_history=False) is False
+    assert profile.data == repaired
+
+
+def test_valid_profile_at_the_tip_is_left_untouched():
+    # The repair is only for profiles that fail the schema; a healthy one must not pay
+    # the cost of a replay, nor collect spurious history.
+    profile = Profile(_valid_profile(), client_id='chemotion')
+    before = copy.deepcopy(profile.data)
+
+    assert Migrations().migrate_profile(profile, force=False, add_history=True) is False
+    assert profile.data == before
+
+
+def test_repair_restores_fields_despite_an_unrelated_defect():
+    # A real profile carried a table header of nulls, which no migration claims to fix.
+    # Demanding full validity would discard a replay that did restore the missing
+    # fields, so the profile would stay unconvertible over an unrelated flaw.
+    broken = _legacy_checkpoint_profile()
+    broken['data'][0]['tables'][0]['header'] = [None, None]
+    profile = Profile(broken, client_id='chemotion')
+
+    applied = Migrations().migrate_profile(profile, force=False, add_history=False)
+
+    assert applied
+    assert isinstance(profile.data['rootOntology'], dict)
+    assert 'subjectInstances' in profile.data
+    # The unrelated defect is still reported rather than silently papered over.
+    assert profile_validation_errors(profile.data)
+
+
+def test_repair_is_abandoned_when_the_replay_would_make_things_worse(monkeypatch):
+    # The safety guarantee: a replay that introduces a *new* violation is discarded.
+    # What survives is the ordinary resume, which is legitimate work -- only the
+    # repair's own replay is rolled back.
+    profile = Profile(_legacy_checkpoint_profile(), client_id='chemotion')
+    original = Migrations._up_migration
+
+    def corrupt(self, last_migration, prof, add_history=True):
+        result = original(self, last_migration, prof, add_history)
+        if last_migration == '':          # only the replay the repair performs
+            prof.data.pop('title', None)  # a required field the original had
+        return result
+
+    monkeypatch.setattr(Migrations, '_up_migration', corrupt)
+
+    # Still True: the resume applied migrations, so the caller must persist them.
+    assert Migrations().migrate_profile(profile, force=False, add_history=False) is True
+    assert 'title' in profile.data, 'the corrupting replay must have been rolled back'
+    # And the replay was discarded wholesale, not cherry-picked: the fields it would
+    # have restored are absent, exactly as they were before the repair was attempted.
+    assert 'rootOntology' not in profile.data
+
+
+# --- the writer must not be the place an incomplete profile is discovered -----
+
+
+def _rdf_writer_for(profile_data):
+    converter = SimpleNamespace(
+        tables=[],
+        profile=SimpleNamespace(as_dict=profile_data),
+        get_matches=lambda rdf=False: [],
+    )
+    return RDFWriter(converter)
+
+
+def test_rdf_writer_falls_back_when_root_ontology_is_missing():
+    # rootOntology is not in the schema's required list, so even a *valid* profile can
+    # reach the writer without one. Indexing it raised KeyError -> HTTP 500, which the
+    # ELN recorded as a failed conversion with no clue why.
+    writer = _rdf_writer_for(_valid_profile())  # valid, yet has no rootOntology
+
+    writer._preprocess()
+
+    assert writer.root_ontology == DEFAULT_ROOT_ONTOLOGY
+
+
+def test_rdf_writer_tolerates_a_wholly_unmigrated_profile():
+    # The worst case: none of the migration-added fields are present.
+    bare = _legacy_checkpoint_profile()
+    writer = _rdf_writer_for(bare)
+
+    writer._preprocess()  # must not raise
+
+    assert writer.subjects == []
+    assert writer.instances == {}


### PR DESCRIPTION
Follow-up to #242. Making the chain resume-safe stopped the crash but not the cause: the profile still came out the far end missing the fields, and the conversion failed later instead.

## The bug

Real profiles are stamped `last_migration = 20260113143334` yet lack `rootOntology` and `subjectInstances` — fields added by `20250908063445`, which is an **ancestor** of that checkpoint. So the checkpoint claims more than was actually applied.

The consequences compound:

1. A resume starts *after* the checkpoint, so the field-adders are never revisited.
2. `20260323144702` only *replaces* an existing default `rootOntology`; with the key absent it does nothing.
3. The chain runs to the tip and re-stamps `last_migration`, so the profile now **looks** fully migrated while staying structurally invalid. Every boot repeats this.
4. `validate_all_profiles` reported the violation at startup and nothing acted on it.
5. The failure surfaced far from its cause — the RDF writer indexing the absent key: `KeyError` → HTTP 500. The ELN recorded a failed conversion, which users reported as *"uploading a file to an analysis-dataset no longer triggers conversion"*.

Only `migrate --force` could escape it, which meant an operator had to know to run it.

## The fix

Treat `last_migration` as a claim and the schema as the ground truth. When a profile still fails validation after a normal resume, distrust the checkpoint and replay the chain from the root.

- **Adopt the replay when it leaves no violation the profile did not already have**, rather than demanding full validity. One real profile carries a table header of nulls that no migration claims to fix; insisting on a clean bill of health would discard a replay that *did* restore the missing fields, leaving that profile unconvertible over an unrelated flaw. A replay that introduces anything new is rolled back, so a repair can never leave a profile worse than it was found.
- **`profile_validation_errors()`** reports every violation instead of stopping at the first, so before/after can be compared. The message is part of the signature because `required` emits one error per absent property, all sharing path and validator — without it every missing field collapses into one indistinguishable entry.
- **The RDF writer reads the migration-added fields defensively.** Worth noting: `rootOntology` is *not* in the schema's `required` list, so even a fully valid profile can reach the writer without one. A conversion should never be the place an incomplete profile is discovered; it now degrades to the generic assay term with a warning.

## Verification

End to end from the untouched legacy profiles, with **no `--force` anywhere**:

- 30/30 profiles missing `rootOntology` heal at startup; boot validation goes from 30 errors to ✅ across the board.
- The sample cyclic-voltammetry `.DTA` converts: **HTTP 200, `application/zip`, 45828 bytes** — matching the result a manual `migrate --force` produced.
- **67 tests pass** (59 existing + 8 new), covering: repair to validity, idempotence on a second boot, healthy profiles left untouched, fields restored despite an unrelated defect, rollback when a replay would make things worse, and both RDF-writer fallbacks.

One profile (`15400217…`) remains schema-invalid after repair — two table headers are `[None, None, None, None]` instead of strings. That is a genuine data defect no migration claims to fix; it now gets its fields restored and converts, and the remaining violation is logged as unresolved rather than passed off as healthy. Worth fixing in the profile editor separately.
